### PR TITLE
Update L_U_NET_architecture.ipynb

### DIFF
--- a/L_U_NET_architecture.ipynb
+++ b/L_U_NET_architecture.ipynb
@@ -151,11 +151,11 @@
       "cell_type": "code",
       "source": [
         "train_img_paths = glob.glob(os.path.join(x_train_dir, \"*.jpg\"))\n",
-        "train_mask_paths = glob.glob(os.path.join(y_train_dir, \"*.gif\"))\n",
+        "train_mask_paths = glob.glob(os.path.join(y_train_dir, \"*.png\"))\n",
         "val_img_paths = glob.glob(os.path.join(x_valid_dir, \"*.jpg\"))\n",
-        "val_mask_paths = glob.glob(os.path.join(y_valid_dir, \"*.gif\"))\n",
+        "val_mask_paths = glob.glob(os.path.join(y_valid_dir, \"*.png\"))\n",
         "test_img_paths = glob.glob(os.path.join(x_test_dir, \"*.jpg\"))\n",
-        "test_mask_paths = glob.glob(os.path.join(y_test_dir, \"*.gif\"))"
+        "test_mask_paths = glob.glob(os.path.join(y_test_dir, \"*.png\"))"
       ],
       "metadata": {
         "id": "xt4b-YO7Z9Yv"
@@ -297,7 +297,7 @@
         "            img_path = self.imagePaths[idx]\n",
         "            mask_path = self.maskPaths[idx]\n",
         "            read_img = cv2.cvtColor(cv2.imread(img_path), cv2.COLOR_BGR2RGB)\n",
-        "            read_img = cv2.resize(read_img, (1152,1728), interpolation = cv2.INTER_AREA)\n",
+        "            # read_img = cv2.resize(read_img, (1152,1728), interpolation = cv2.INTER_AREA)\n",
         "            img = 2*((read_img - read_img.min()) / (read_img.max() - read_img.min())) - 1\n",
         "            mask = pil_loader(mask_path)\n",
         "            #mask to numpy\n",


### PR DESCRIPTION
DIVA-HisDB dataset GT masks are shared as PNGs and are currently same size as the GT imgs so no need to resize

Modifications
* png instead of gif
* commit resize line in dataloader.